### PR TITLE
Add babel-preset-react

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "license": "MIT",
   "dependencies": {
     "babel-preset-es2015": "^6.5.0",
+    "babel-preset-react": "^6.5.0",
     "babelify": "^7.2.0",
     "browserify": "^13.0.0",
     "browserify-incremental": "^3.0.1",


### PR DESCRIPTION
I've added `babel-preset-react` because missing preset causes error in browserify process.