### PR TITLE
Change callback for triggering preview from onKeydown to onChange

### DIFF
--- a/app/assets/javascripts/editor.jsx
+++ b/app/assets/javascripts/editor.jsx
@@ -6,7 +6,7 @@ var NoteTextArea = React.createClass({
     App.note.preview(document.getElementById('note_body').value);
   },
 
-  handleKeyDown: function(event){
+  handleChange: function(event) {
     App.note.preview(event.target.value);
   },
 
@@ -15,7 +15,7 @@ var NoteTextArea = React.createClass({
       <div className="col-md-6">
         <div className="form-group is-empty">
           <label className="control-label">Body</label>
-          <textarea rows="35" className="form-control" data-behavior="writer" name="note[body]" id="note_body" onKeyDown={this.handleKeyDown} defaultValue={this.props.body}></textarea>
+          <textarea rows="35" className="form-control" data-behavior="writer" name="note[body]" id="note_body" onChange={this.handleChange} defaultValue={this.props.body}></textarea>
           <span className="material-input" />
         </div>
       </div>


### PR DESCRIPTION
Why don't you use `onChange` callback for triggering preview?

Since `onKeydown` is fired only when a key is pressed, that means if you input something like `abcde`, the last `e` won't be appeared in preview in contrast to `onChange` which is always invoked when the input value has changed.