### PR TITLE
Reduce logger because of limit of papertrail

### DIFF
--- a/config/initializers/action_cable.rb
+++ b/config/initializers/action_cable.rb
@@ -1,0 +1,3 @@
+Rails.application.config.after_initialize do
+  ActionCable.server.config.logger = Logger.new '/dev/null'
+end

--- a/config/initializers/active_job.rb
+++ b/config/initializers/active_job.rb
@@ -1,0 +1,3 @@
+Rails.application.config.after_initialize do
+  ActiveJob::Base.logger = Logger.new '/dev/null'
+end


### PR DESCRIPTION
Papertrailの転送量制限でひっかかってしまうので、actioncableとactivejobのログ出力を抑えるようにしました。