### PR TITLE
yarnを無効にする

### DIFF
--- a/.slugignore
+++ b/.slugignore
@@ -1,0 +1,1 @@
+/yarn.lock


### PR DESCRIPTION
heroku上でライブラリの依存関係をうまく解決できていないようなので一時的にyarnを無効にします。